### PR TITLE
add description

### DIFF
--- a/GeoHex3.podspec
+++ b/GeoHex3.podspec
@@ -17,6 +17,8 @@ Pod::Spec.new do |s|
 #   * Write the description between the DESC delimiters below.
 #   * Finally, don't worry about the indent, CocoaPods strips it!  
   s.description      = <<-DESC
+                       GeoHex 3.2 framework for Swift.
+                       A wrapper for c-geohex3.
                        DESC
 
   s.homepage         = "https://github.com/karupanerura/swift-GeoHex3"


### PR DESCRIPTION
In CocoaPods 1.0.0 beta3, `pod install` command needs description of pod.
